### PR TITLE
Add python-minimal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.python-minimal?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=183&branchName=master)
+
+# python-minimal
+
+This package is intended to be used only as a build dependency for glibc.
+
+If you would like to use Python in your applications, please look at `core/python` or one of the other versioned Python packages.
+
+## Why does this package exist?
+
+With glibc2.29, python was introduced as a build dependency. If we were to include `core/python` as a build dependency for `core/glibc`
+it would increase the number of items that are considered "base plans", i.e. plans that are required in order to bootstrap the Habitat
+ecosystem. This would make packages like Python and sqlite more difficult to update. Having `core/python` as a build dependency for
+`core/glibc` means that the footprint of packages that would cause the world to rebuild would be greatly increased, resulting in slower
+updates for those packages or more churn across our entire ecosystem.
+
+As a result, this package (`python-minimal`) was introduced so that we have a version of Python that has minimal depdencies, should need
+infrequent updates, and keeps the number of packages that would cause a "world rebuild" to a minimum.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name : "python-minimal"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,4 +15,4 @@ resources:
 
 # Execute the stages from the main pipeline template
 stages:
-  - template: azure-pipelines.yml@plan_builder
+  - template: azure-pipelines-package-install.yml@plan_builder

--- a/controls/python_works.rb
+++ b/controls/python_works.rb
@@ -2,7 +2,7 @@ title 'Tests to confirm python-minimal works as expected'
 
 plan_name = input('plan_name', value: 'python-minimal')
 plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
-hab_path = input('hab_path', value: 'hab')
+hab_path = input('hab_path', value: '/tmp/hab')
 
 control 'core-plans-python-minimal' do
   impact 1.0
@@ -29,13 +29,11 @@ control 'core-plans-python-minimal' do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
     its('stdout') { should match /Python\s+#{python_pkg_ident.split('/')[5]}/ }
-    its('stderr') { should be_empty }
   end
 
   describe command("#{python_pkg_ident}/bin/python -c \"print('hello world')\"") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
     its('stdout') { should match /hello world/ }
-    its('stderr') { should be_empty }
   end
 end

--- a/controls/python_works.rb
+++ b/controls/python_works.rb
@@ -1,0 +1,41 @@
+title 'Tests to confirm python-minimal works as expected'
+
+plan_name = input('plan_name', value: 'python-minimal')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+hab_path = input('hab_path', value: 'hab')
+
+control 'core-plans-python-minimal' do
+  impact 1.0
+  title 'Ensure python-minimal works'
+  desc '
+  For python we check that the version is correctly returned e.g.
+
+    $ python --version
+    Python 3.8.3
+
+  As is often customary, we also say hello to the world with python:
+
+    $ python -c "print(\'hello world\')"
+    hello world
+  '
+  python_pkg_ident = command("#{hab_path} pkg path #{plan_ident}")
+  describe python_pkg_ident do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  python_pkg_ident = python_pkg_ident.stdout.strip
+
+  describe command("#{python_pkg_ident}/bin/python --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /Python\s+#{python_pkg_ident.split('/')[5]}/ }
+    its('stderr') { should be_empty }
+  end
+
+  describe command("#{python_pkg_ident}/bin/python -c \"print('hello world')\"") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /hello world/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
+name: python-minimal
+title: Habitat Core Plan for python-minimal
 maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
+summary: InSpec controls for testing Habitat Core Plan for python-minimal
 copyright: humans@habitat.sh
 copyright_email: humans@habitat.sh
 version: 0.1.0

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,62 @@
+pkg_name=python-minimal
+pkg_distname=Python
+pkg_version=3.7.0
+pkg_origin=core
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('Python-2.0')
+pkg_description="Python is a programming language that lets you work quickly \
+  and integrate systems more effectively. \
+  \
+  This package is not intended for regular use. Please use core/python instead."
+pkg_upstream_url="https://www.python.org"
+pkg_dirname="${pkg_distname}-${pkg_version}"
+pkg_source="https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz"
+pkg_shasum="85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d"
+
+pkg_bin_dirs=(bin)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_interpreters=(bin/python bin/python3 bin/python3.7)
+
+pkg_deps=(
+  core/gcc-libs
+  core/glibc
+)
+
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/gcc
+  core/linux-headers
+  core/make
+  core/util-linux
+)
+
+do_build() {
+  export LDFLAGS="$LDFLAGS -lgcc_s"
+
+  ./configure --prefix="$pkg_prefix" --without-ensurepip
+  make
+}
+
+do_install() {
+  do_default_install
+
+  # link pythonx.x to python for pkg_interpreters
+  local minor=${pkg_version%.*}
+  local major=${minor%.*}
+  ln -rs "$pkg_prefix/bin/pip$minor" "$pkg_prefix/bin/pip"
+  ln -rs "$pkg_prefix/bin/pydoc$minor" "$pkg_prefix/bin/pydoc"
+  ln -rs "$pkg_prefix/bin/python$minor" "$pkg_prefix/bin/python"
+  ln -rs "$pkg_prefix/bin/python$minor-config" "$pkg_prefix/bin/python-config"
+
+  # Remove idle as we are not building with Tk/x11 support so it is useless
+  rm -vf "$pkg_prefix/bin/idle$major"
+  rm -vf "$pkg_prefix/bin/idle$minor"
+
+  platlib=$(python -c "import sysconfig;print(sysconfig.get_path('platlib'))")
+  cat <<EOF > "$platlib/_manylinux.py"
+# Disable binary manylinux1(CentOS 5) wheel support
+manylinux1_compatible = False
+EOF
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+echo "This package is intended only for use with build glibc."
+echo "Please verify any changes to this by building glibc with the updated version of this package."


### PR DESCRIPTION
Migration from core-plans plus inspec tests.  Uses local package build.

```
Version: 0.1.0
Target:  local://

  ✔  core-plans-python-minimal: Ensure python-minimal works
     ✔  Command: `hab pkg path habskp/python-minimal` exit_status is expected to eq 0
     ✔  Command: `hab pkg path habskp/python-minimal` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/python-minimal/3.7.0/20200611122957/bin/python --version` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/python-minimal/3.7.0/20200611122957/bin/python --version` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/python-minimal/3.7.0/20200611122957/bin/python --version` stdout is expected to match /Python\s+3.7.0/
     ✔  Command: `/hab/pkgs/habskp/python-minimal/3.7.0/20200611122957/bin/python --version` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/habskp/python-minimal/3.7.0/20200611122957/bin/python -c "print('hello world')"` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/python-minimal/3.7.0/20200611122957/bin/python -c "print('hello world')"` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/python-minimal/3.7.0/20200611122957/bin/python -c "print('hello world')"` stdout is expected to match /hello world/
     ✔  Command: `/hab/pkgs/habskp/python-minimal/3.7.0/20200611122957/bin/python -c "print('hello world')"` stderr is expected to be empty
```

﻿Signed-off-by: Stuart Paterson <spaterson@chef.io>
